### PR TITLE
HOTFIX: Allow for missing annotators

### DIFF
--- a/src/main/scala/au/edu/utscic/athanorserver/corenlp/ConstituentTreeParser.scala
+++ b/src/main/scala/au/edu/utscic/athanorserver/corenlp/ConstituentTreeParser.scala
@@ -10,10 +10,14 @@ import org.json4s.{JValue, NoTypeHints}
   */
 object ConstituentTreeParser {
 
-  def parse(tree:Tree):ConstituentTree = {
-    val treeList = process(tree)
-    //listToJsonString(treeList.asInstanceOf[List[Serializable]])
-    treeList.asInstanceOf[ConstituentTree]
+  def parse(tree:Option[Tree]):ConstituentTree = {
+    tree match {
+      case None => List()
+      case Some(t) => {
+        val treeList = process(t)
+        treeList.asInstanceOf[ConstituentTree]
+      }
+    }
   }
 
   def process(tree:Tree):Any = {

--- a/src/main/scala/au/edu/utscic/athanorserver/corenlp/SentenceParser.scala
+++ b/src/main/scala/au/edu/utscic/athanorserver/corenlp/SentenceParser.scala
@@ -15,7 +15,7 @@ import scala.collection.immutable.SortedMap
   */
 object SentenceParser {
 
-  def parse(tokens:List[CoreLabel],constituentTree:Tree,dependencies:SemanticGraph):ParsedSentence = {
+  def parse(tokens:List[CoreLabel],constituentTree:Option[Tree],dependencies:Option[SemanticGraph]):ParsedSentence = {
     val ln:LexicalNodes = getNodes(tokens)
     val ct:ConstituentTree = getTree(constituentTree)
     val dp:Dependencies = getDependencies(dependencies)
@@ -45,17 +45,22 @@ object SentenceParser {
     SortedMap[Int,Node](0 -> Node(0,"ROOT",None,None,None,None,None,None)) ++ nodes
   }
 
-  def getTree(constituentTree: Tree):ConstituentTree = {
-      ConstituentTreeParser.parse(constituentTree)
+  def getTree(constituentTree: Option[Tree]):ConstituentTree = {
+    ConstituentTreeParser.parse(constituentTree)
   }
 
-  def getDependencies(dependencies:SemanticGraph):Dependencies = {
-    dependencies.edgeListSorted().asScala.toList.map { d =>
-      Dependency(
-        d.getRelation.toString,
-        d.getGovernor.backingLabel().index(),
-        d.getDependent.backingLabel().index()
-      )
+  def getDependencies(dependencies:Option[SemanticGraph]):Dependencies = {
+    dependencies match {
+      case None => List()
+      case Some(deps) => {
+        deps.edgeListSorted().asScala.toList.map { d =>
+          Dependency(
+            d.getRelation.toString,
+            d.getGovernor.backingLabel().index(),
+            d.getDependent.backingLabel().index()
+          )
+        }
+      }
     }
   }
 }

--- a/src/main/scala/au/edu/utscic/athanorserver/corenlp/TextParser.scala
+++ b/src/main/scala/au/edu/utscic/athanorserver/corenlp/TextParser.scala
@@ -22,7 +22,7 @@ object TextParser {
 
   val pipeline:StanfordCoreNLP = {
     val props = new Properties
-    props.setProperty("annotators", "tokenize, ssplit, pos, lemma, parse") //ner dcoref
+    props.setProperty("annotators", "tokenize, ssplit, pos, lemma, parse") //parse ner dcoref
     new StanfordCoreNLP(props)
   }
 
@@ -40,10 +40,15 @@ object TextParser {
   def parseSentences(sentences:List[CoreMap]):List[ParsedSentence] = {
     sentences.map { sentence =>
       val tokens = getTokens(sentence)
-      val tree:Tree = sentence.get(classOf[TreeAnnotation])
-      val dependencies:SemanticGraph = sentence.get(classOf[EnhancedPlusPlusDependenciesAnnotation])
+      val tree:Option[Tree] = getAsOption(sentence.get(classOf[TreeAnnotation]))
+      val dependencies:Option[SemanticGraph] = getAsOption(sentence.get(classOf[EnhancedPlusPlusDependenciesAnnotation]))
       SentenceParser.parse(tokens,tree,dependencies)
     }
+  }
+
+  def getAsOption[T](c:Any) = c match {
+    case null => None
+    case t:T => Some(t)
   }
 
   def getTokens(sentence:CoreMap):List[CoreLabel] = sentence.get(classOf[TokensAnnotation]).asScala.toList

--- a/src/test/scala/au/edu/utscic/athanorserver/corenlp/CoreNlpSpec.scala
+++ b/src/test/scala/au/edu/utscic/athanorserver/corenlp/CoreNlpSpec.scala
@@ -16,8 +16,8 @@ class CoreNlpSpec extends UnitSpec {
   lazy val annotatedSent = TextParser.annotateSentences(textA)
   lazy val parsedSents = TextParser.parseSentences(annotatedSent)
   lazy val tokens1 = TextParser.getTokens(annotatedSent(0))
-  lazy val constTree1 = annotatedSent(0).get(classOf[TreeAnnotation])
-  lazy val semGraph1 = annotatedSent(0).get(classOf[EnhancedPlusPlusDependenciesAnnotation])
+  lazy val constTree1 = Some(annotatedSent(0).get(classOf[TreeAnnotation]))
+  lazy val semGraph1 = Some(annotatedSent(0).get(classOf[EnhancedPlusPlusDependenciesAnnotation]))
 
 
   behavior of "TextParser"
@@ -88,7 +88,7 @@ class CoreNlpSpec extends UnitSpec {
   behavior of "ConstituentTreeParser"
 
   it should "process" in {
-    val res = ConstituentTreeParser.process(constTree1)
+    val res = ConstituentTreeParser.process(constTree1.get)
     assert(res==textAconstTree1)
   }
 


### PR DESCRIPTION
Handle Java null values when annotators are not included in the pipeline