### PR TITLE
Implement athanor project dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,29 @@
+packAutoSettings
 name := "athanorserver"
+
+//
+// Athanor has been modified to be a pretend SBT project so that it is
+// a dependency of this project. The dependency will be downloaded by SBT
+// to the staging areas, and its jars become accessible to us.
+// The implemented project dependency scheme is described in:
+// [sbt reference manual-multi project build](http://www.scala-sbt.org/0.13/docs/Multi-Project.html)
+//
+dependsOn(athanorProject)
+
+// This git branch should contain the athanor jar that we depend on. An athanor dummy sbt 
+// project has been created in athanor, and the lib directory of athanor contains a link to the 
+// jar that we default to. This jar does not need to be copied to the athanor-server lib directory
+// as athanor is a dependency and the jar seems to be picked up. 
+lazy val athanorProject = ProjectRef(uri("https://github.com/uts-cic/athanor.git#develop"),"athanor")
+
+// This is the git branch that I tested with. For the final version, we can try specifying 
+// the develop branch, or see if we can omit the branch all together. 
+// lazy val athanorProject = ProjectRef(uri("https://github.com/josephharfouch/athanor.git#dummy_sbt_project"),"athanor")
+
 version := "0.8"
 scalaVersion := "2.12.3"
 organization := "au.edu.utscic"
-
+ 
 //Scala library versions
 val akkaVersion = "2.5.6"
 val akkaStreamVersion = "2.5.6"
@@ -32,21 +53,30 @@ libraryDependencies ++= Seq(
   "edu.stanford.nlp" % "stanford-corenlp" % coreNlpVersion  classifier "models-english"
 )
 
+
 //General
 libraryDependencies ++= Seq(
-  "io.nlytx" %% "commons" % nlytxCommonsVersion,
+  // Please see comments below about disabling nlytx dependency
+  //"io.nlytx" %% "commons" % nlytxCommonsVersion,
   //  "com.typesafe" % "config" % "1.3.1",
   "org.json4s" %% "json4s-jackson" % json4sVersion,
   "de.heikoseeberger" %% "akka-http-json4s" % akkaHttpJson4sVersion,
   "org.skyscreamer" % "jsonassert" % jsonassertVersion,
   "org.scalatest" %% "scalatest" % scalatestVersion % "test",
   "org.slf4j" % "jcl-over-slf4j" % slf4jVersion,
-  "ch.qos.logback" % "logback-classic" % logbackVersion % Runtime
+  "ch.qos.logback" % "logback-classic" % logbackVersion % Runtime 
 )
 
 scalacOptions in (Compile, doc) ++= Seq("-doc-root-content", baseDirectory.value+"/src/main/scala/root-doc.md")
 
-resolvers += Resolver.bintrayRepo("nlytx", "nlytx_commons")
+//
+// I disabled nlytx dependency for the time being, until we figure out
+// what to do with it. When I delete my private .ivy2 cache, sbt
+// tries to download this dependency but cannot find it. I suspect its 
+// position in the bintray may have moved, but need to do more investigation 
+// on this. I found that when I disable this dependency, the testcases still
+// run. so I am not sure if the dependency is still needed or not. 
+// resolvers += Resolver.bintrayRepo("nlytx", "nlytx_commons")
 
 //Documentation - run ;paradox;copyDocs
 enablePlugins(ParadoxPlugin) //Generate documentation with Paradox
@@ -63,13 +93,48 @@ copyDocsTask := {
   val docSourceFileName = "target/paradox/site"
   if (! new java.io.File(docSourceFileName).exists)
   {
-      println("Error: Cannot locate documentation source directory:{}", docSourceFileName)
-      System.exit(1)
+    println("Error: Cannot locate documentation source directory:{}", docSourceFileName)
+    System.exit(1)
   }
   val docSource = new File(docSourceFileName)
  
   val docDest = new File("docs")
   IO.copyDirectory(docSource,docDest,overwrite=true,preserveLastModified=true)
+}
+
+
+//Task for downloading an athanor library by typing: sbt downloadAthanor
+// I left this in for now, in case we need to get back to it, or someone needs
+// to adapt it for their own private use, but it would
+// need modifications to work reliably. Not only is the location of the
+// file hidden as documented below, but I suspect that the token would
+// expire or would not work for other users, so I suspect it has to
+// be obtained programmatically from git, which gets us into git
+// authentication via api/url. In any case, I prefer the project
+// dependency scheme where the user does not have to type any
+// extra commands, and that would make this task unnecessary.
+val downloadAthanorTask = TaskKey[Unit]("downloadAthanor","copies Athanor library to the lib/ directory")
+downloadAthanorTask := {
+
+  import java.io.File
+  import java.nio.file.Paths
+  import java.nio.file.Files
+  import java.nio.file.StandardCopyOption._
+
+
+
+  //
+  // The difficulty with this is that the real location of the file in github is hidden, and I had to capture what the load command was
+  // doing by right clicking on the file and doing a load to see where the load was getting the file from
+  // We have to do this in the future if we want to update to a different version of the athanor library. 
+  //
+  val athanorSourceJarName = "https://raw.githubusercontent.com/uts-cic/athanor/develop/java/versioned_dist/athanor-0.87b-1.0.0.jar?token=AfHf5cx0BAP0hVxlxh7oqvTuYVecPmkyks5aDa47wA%3D%3D"
+  val athanorTargetJarName = "lib/athanor.jar"
+
+  val athanorSourceJar = new URL(athanorSourceJarName)
+  val in = athanorSourceJar.openStream()
+  val out = Paths.get(athanorTargetJarName)
+  Files.copy(in, out, REPLACE_EXISTING);
 }
 
 // RUN sbt dependencyUpdates to check dependency version

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,6 @@ addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.0-M9")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.2.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")
+addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.7.9") 
+
+

--- a/src/main/paradox/developer/athanor_interface.md
+++ b/src/main/paradox/developer/athanor_interface.md
@@ -3,17 +3,23 @@
 
 ### Customizing the Athanor Library version
 
-The Athanor server repository contains a packaged build of Athanor in the lib directory.
+The Athanor server repository contains a packaged build of Athanor in the lib directory
+of the Athanor staging area (By default HOME_DIR/.sbt/0.13/staging). 
+
 
     ls lib
 
-    -rw-rw-r-- 1 7872063 jatanor-0.87b10.jar
+    ------ athanor.jar
     
     
-If you want to work with a different version of Athanor, download the Athanor repository
+If you want to work with a different version of Athanor, download the Athanor repository, 
+or work with the Athanor repository in the staging area.  
 and copy or link to one of the jar versions in athanor/java/versioned_dist/.
 Alternatively, follow the README.md instructions of the athanor project to produce java/dist/jatanor.jar
 and link to or copy that jar in order to work with the latest version of the Athanor code.
+
+If you work in the staging area, you might need to remove this staging area, to let sbt 
+return to the default once you finished your work. 
 
 For example, assuming Athanor-server and Athanor are installed in your home directory:
 

--- a/src/main/paradox/user/build_product.md
+++ b/src/main/paradox/user/build_product.md
@@ -12,6 +12,8 @@ on how the build is done:
      in the ~/.ivy2 directory.
 
          sbt compile
+         
+       
 
      The following compile warnings seem to be safe to ignore, but ensure the
      last compile ends with [SUCCESS] :
@@ -31,3 +33,10 @@ on how the build is done:
          [warn] there was one feature warning; re-run with -feature for details
          [warn] three warnings found
          [success] Total time: 7 s, completed Oct 19, 2017 12:13:14 PM
+         
+    The athanor jar library which is a dependency of this project should be fetched automatically by
+    the sbt compile step. If you get the following error , it means the dependency has not been
+    resolved. In this case try issuing sbt update, or deleting the staging area (By default HOME_DIRECTORY/.sbt/0.13/staging):
+    
+         HOME_DIR/athanor-server/src/main/scala/au/edu/utscic/athanorserver/athanor/Athanor.scala:25: not found: type JAtanor
+         [error]   lazy val athanor = new JAtanor


### PR DESCRIPTION
In this change, we remove the athanor jar that ideally belongs to
the athanor project, and resolve a versioned distribution jar
that is automatically downloaded with the athanor project
which is now a dependency of this project. An athanor.jar
link in the athanor project directory points to the
versioned jar that we are dependent on my default.